### PR TITLE
addrman, rpc: improve getrawaddrman performance when used with `-asmap` by caching ASNs in AddrInfo

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -283,6 +283,8 @@ void AddrManImpl::Unserialize(Stream& s_)
     for (int n = 0; n < nNew; n++) {
         AddrInfo& info = mapInfo[n];
         s >> info;
+        info.mapped_as = m_netgroupman.GetMappedAS(info);
+        info.source_mapped_as = m_netgroupman.GetMappedAS(info.source);
         mapAddr[info] = n;
         info.nRandomPos = vRandom.size();
         vRandom.push_back(n);
@@ -295,6 +297,8 @@ void AddrManImpl::Unserialize(Stream& s_)
     for (int n = 0; n < nTried; n++) {
         AddrInfo info;
         s >> info;
+        info.mapped_as = m_netgroupman.GetMappedAS(info);
+        info.source_mapped_as = m_netgroupman.GetMappedAS(info.source);
         int nKBucket = info.GetTriedBucket(nKey, m_netgroupman);
         int nKBucketPos = info.GetBucketPosition(nKey, false, nKBucket);
         if (info.IsValid()
@@ -418,7 +422,7 @@ AddrInfo* AddrManImpl::Create(const CAddress& addr, const CNetAddr& addrSource, 
     AssertLockHeld(cs);
 
     nid_type nId = nIdCount++;
-    mapInfo[nId] = AddrInfo(addr, addrSource);
+    mapInfo[nId] = AddrInfo(addr, m_netgroupman.GetMappedAS(addr), addrSource, m_netgroupman.GetMappedAS(addrSource));
     mapAddr[addr] = nId;
     mapInfo[nId].nRandomPos = vRandom.size();
     vRandom.push_back(nId);
@@ -611,9 +615,8 @@ bool AddrManImpl::AddSingle(const CAddress& addr, const CNetAddr& source, std::c
             ClearNew(nUBucket, nUBucketPos);
             pinfo->nRefCount++;
             vvNew[nUBucket][nUBucketPos] = nId;
-            const auto mapped_as{m_netgroupman.GetMappedAS(addr)};
             LogDebug(BCLog::ADDRMAN, "Added %s%s to new[%i][%i]\n",
-                     addr.ToStringAddrPort(), (mapped_as ? strprintf(" mapped to AS%i", mapped_as) : ""), nUBucket, nUBucketPos);
+                     addr.ToStringAddrPort(), (pinfo->mapped_as ? strprintf(" mapped to AS%i", pinfo->mapped_as) : ""), nUBucket, nUBucketPos);
         } else {
             if (pinfo->nRefCount == 0) {
                 Delete(nId);
@@ -671,9 +674,8 @@ bool AddrManImpl::Good_(const CService& addr, bool test_before_evict, NodeSecond
     } else {
         // move nId to the tried tables
         MakeTried(info, nId);
-        const auto mapped_as{m_netgroupman.GetMappedAS(addr)};
         LogDebug(BCLog::ADDRMAN, "Moved %s%s to tried[%i][%i]\n",
-                 addr.ToStringAddrPort(), (mapped_as ? strprintf(" mapped to AS%i", mapped_as) : ""), tried_bucket, tried_bucket_pos);
+                 addr.ToStringAddrPort(), (info.mapped_as ? strprintf(" mapped to AS%i", info.mapped_as) : ""), tried_bucket, tried_bucket_pos);
         return true;
     }
 }

--- a/src/addrman_impl.h
+++ b/src/addrman_impl.h
@@ -51,8 +51,14 @@ public:
     //! last counted attempt (memory only)
     NodeSeconds m_last_count_attempt{0s};
 
+    //! The ASN of the address.
+    uint32_t mapped_as;
+
     //! where knowledge about this address first came from
     CNetAddr source;
+
+    //! The ASN of the source address.
+    uint32_t source_mapped_as;
 
     //! last successful connection by us
     NodeSeconds m_last_success{0s};
@@ -74,11 +80,12 @@ public:
         READWRITE(AsBase<CAddress>(obj), obj.source, Using<ChronoFormatter<int64_t>>(obj.m_last_success), obj.nAttempts);
     }
 
-    AddrInfo(const CAddress &addrIn, const CNetAddr &addrSource) : CAddress(addrIn), source(addrSource)
+    AddrInfo(const CAddress &addrIn, const uint32_t mapped_as, const CNetAddr &addrSource, const uint32_t source_mapped_as) :
+        CAddress(addrIn), mapped_as(mapped_as), source(addrSource), source_mapped_as(source_mapped_as)
     {
     }
 
-    AddrInfo() : CAddress(), source()
+    AddrInfo() : CAddress(), mapped_as(), source(), source_mapped_as()
     {
     }
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -1117,13 +1117,12 @@ static RPCHelpMan getaddrmaninfo()
     };
 }
 
-UniValue AddrmanEntryToJSON(const AddrInfo& info, const CConnman& connman)
+UniValue AddrmanEntryToJSON(const AddrInfo& info)
 {
     UniValue ret(UniValue::VOBJ);
     ret.pushKV("address", info.ToStringAddr());
-    const uint32_t mapped_as{connman.GetMappedAS(info)};
-    if (mapped_as) {
-        ret.pushKV("mapped_as", mapped_as);
+    if (info.mapped_as) {
+        ret.pushKV("mapped_as", info.mapped_as);
     }
     ret.pushKV("port", info.GetPort());
     ret.pushKV("services", static_cast<std::underlying_type_t<decltype(info.nServices)>>(info.nServices));
@@ -1131,14 +1130,13 @@ UniValue AddrmanEntryToJSON(const AddrInfo& info, const CConnman& connman)
     ret.pushKV("network", GetNetworkName(info.GetNetClass()));
     ret.pushKV("source", info.source.ToStringAddr());
     ret.pushKV("source_network", GetNetworkName(info.source.GetNetClass()));
-    const uint32_t source_mapped_as{connman.GetMappedAS(info.source)};
-    if (source_mapped_as) {
-        ret.pushKV("source_mapped_as", source_mapped_as);
+    if (info.source_mapped_as) {
+        ret.pushKV("source_mapped_as", info.source_mapped_as);
     }
     return ret;
 }
 
-UniValue AddrmanTableToJSON(const std::vector<std::pair<AddrInfo, AddressPosition>>& tableInfos, const CConnman& connman)
+UniValue AddrmanTableToJSON(const std::vector<std::pair<AddrInfo, AddressPosition>>& tableInfos)
 {
     UniValue table(UniValue::VOBJ);
     for (const auto& e : tableInfos) {
@@ -1149,7 +1147,7 @@ UniValue AddrmanTableToJSON(const std::vector<std::pair<AddrInfo, AddressPositio
         // Address manager tables have unique entries so there is no advantage
         // in using UniValue::pushKV, which checks if the key already exists
         // in O(N). UniValue::pushKVEnd is used instead which currently is O(1).
-        table.pushKVEnd(key.str(), AddrmanEntryToJSON(info, connman));
+        table.pushKVEnd(key.str(), AddrmanEntryToJSON(info));
     }
     return table;
 }
@@ -1183,12 +1181,10 @@ static RPCHelpMan getrawaddrman()
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
             AddrMan& addrman = EnsureAnyAddrman(request.context);
-            NodeContext& node_context = EnsureAnyNodeContext(request.context);
-            CConnman& connman = EnsureConnman(node_context);
 
             UniValue ret(UniValue::VOBJ);
-            ret.pushKV("new", AddrmanTableToJSON(addrman.GetEntries(false), connman));
-            ret.pushKV("tried", AddrmanTableToJSON(addrman.GetEntries(true), connman));
+            ret.pushKV("new", AddrmanTableToJSON(addrman.GetEntries(false)));
+            ret.pushKV("tried", AddrmanTableToJSON(addrman.GetEntries(true)));
             return ret;
         },
     };

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -27,6 +27,8 @@ using util::ToString;
 
 static auto EMPTY_NETGROUPMAN{NetGroupManager::NoAsmap()};
 static const bool DETERMINISTIC{true};
+static const uint32_t TEST_ASN = 1245;
+static const uint32_t TEST_SOURCE_ASN = 2345;
 
 static int32_t GetCheckRatio(const NodeContext& node_ctx)
 {
@@ -505,7 +507,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket_legacy)
     CNetAddr source1 = ResolveIP("250.1.1.1");
 
 
-    AddrInfo info1 = AddrInfo(addr1, source1);
+    AddrInfo info1 = AddrInfo(addr1, TEST_ASN, source1, TEST_SOURCE_ASN);
 
     uint256 nKey1 = (HashWriter{} << 1).GetHash();
     uint256 nKey2 = (HashWriter{} << 2).GetHash();
@@ -518,7 +520,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket_legacy)
 
     // Test: Two addresses with same IP but different ports can map to
     //  different buckets because they have different keys.
-    AddrInfo info2 = AddrInfo(addr2, source1);
+    AddrInfo info2 = AddrInfo(addr2, TEST_ASN, source1, TEST_SOURCE_ASN);
 
     BOOST_CHECK(info1.GetKey() != info2.GetKey());
     BOOST_CHECK(info1.GetTriedBucket(nKey1, EMPTY_NETGROUPMAN) != info2.GetTriedBucket(nKey1, EMPTY_NETGROUPMAN));
@@ -527,7 +529,10 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket_legacy)
     for (int i = 0; i < 255; i++) {
         AddrInfo infoi = AddrInfo(
             CAddress(ResolveService("250.1.1." + ToString(i)), NODE_NONE),
-            ResolveIP("250.1.1." + ToString(i)));
+            TEST_ASN,
+            ResolveIP("250.1.1." + ToString(i)),
+            TEST_SOURCE_ASN
+        );
         int bucket = infoi.GetTriedBucket(nKey1, EMPTY_NETGROUPMAN);
         buckets.insert(bucket);
     }
@@ -539,7 +544,10 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket_legacy)
     for (int j = 0; j < 255; j++) {
         AddrInfo infoj = AddrInfo(
             CAddress(ResolveService("250." + ToString(j) + ".1.1"), NODE_NONE),
-            ResolveIP("250." + ToString(j) + ".1.1"));
+            TEST_ASN,
+            ResolveIP("250." + ToString(j) + ".1.1"),
+            TEST_SOURCE_ASN
+        );
         int bucket = infoj.GetTriedBucket(nKey1, EMPTY_NETGROUPMAN);
         buckets.insert(bucket);
     }
@@ -555,7 +563,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket_legacy)
 
     CNetAddr source1 = ResolveIP("250.1.2.1");
 
-    AddrInfo info1 = AddrInfo(addr1, source1);
+    AddrInfo info1 = AddrInfo(addr1, TEST_ASN, source1, TEST_SOURCE_ASN);
 
     uint256 nKey1 = (HashWriter{} << 1).GetHash();
     uint256 nKey2 = (HashWriter{} << 2).GetHash();
@@ -569,7 +577,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket_legacy)
     BOOST_CHECK(info1.GetNewBucket(nKey1, EMPTY_NETGROUPMAN) != info1.GetNewBucket(nKey2, EMPTY_NETGROUPMAN));
 
     // Test: Ports should not affect bucket placement in the addr
-    AddrInfo info2 = AddrInfo(addr2, source1);
+    AddrInfo info2 = AddrInfo(addr2, TEST_ASN, source1, TEST_SOURCE_ASN);
     BOOST_CHECK(info1.GetKey() != info2.GetKey());
     BOOST_CHECK_EQUAL(info1.GetNewBucket(nKey1, EMPTY_NETGROUPMAN), info2.GetNewBucket(nKey1, EMPTY_NETGROUPMAN));
 
@@ -577,7 +585,10 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket_legacy)
     for (int i = 0; i < 255; i++) {
         AddrInfo infoi = AddrInfo(
             CAddress(ResolveService("250.1.1." + ToString(i)), NODE_NONE),
-            ResolveIP("250.1.1." + ToString(i)));
+            TEST_ASN,
+            ResolveIP("250.1.1." + ToString(i)),
+            TEST_SOURCE_ASN
+        );
         int bucket = infoi.GetNewBucket(nKey1, EMPTY_NETGROUPMAN);
         buckets.insert(bucket);
     }
@@ -590,7 +601,10 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket_legacy)
         AddrInfo infoj = AddrInfo(CAddress(
                                         ResolveService(
                                             ToString(250 + (j / 255)) + "." + ToString(j % 256) + ".1.1"), NODE_NONE),
-            ResolveIP("251.4.1.1"));
+            TEST_ASN,
+            ResolveIP("251.4.1.1"),
+            TEST_SOURCE_ASN
+        );
         int bucket = infoj.GetNewBucket(nKey1, EMPTY_NETGROUPMAN);
         buckets.insert(bucket);
     }
@@ -602,7 +616,10 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket_legacy)
     for (int p = 0; p < 255; p++) {
         AddrInfo infoj = AddrInfo(
             CAddress(ResolveService("250.1.1.1"), NODE_NONE),
-            ResolveIP("250." + ToString(p) + ".1.1"));
+            TEST_ASN,
+            ResolveIP("250." + ToString(p) + ".1.1"),
+            TEST_SOURCE_ASN
+        );
         int bucket = infoj.GetNewBucket(nKey1, EMPTY_NETGROUPMAN);
         buckets.insert(bucket);
     }
@@ -632,7 +649,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
     CNetAddr source1 = ResolveIP("250.1.1.1");
 
 
-    AddrInfo info1 = AddrInfo(addr1, source1);
+    AddrInfo info1 = AddrInfo(addr1, TEST_ASN, source1, TEST_SOURCE_ASN);
 
     uint256 nKey1 = (HashWriter{} << 1).GetHash();
     uint256 nKey2 = (HashWriter{} << 2).GetHash();
@@ -645,7 +662,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
 
     // Test: Two addresses with same IP but different ports can map to
     //  different buckets because they have different keys.
-    AddrInfo info2 = AddrInfo(addr2, source1);
+    AddrInfo info2 = AddrInfo(addr2, TEST_ASN, source1, TEST_SOURCE_ASN);
 
     BOOST_CHECK(info1.GetKey() != info2.GetKey());
     BOOST_CHECK(info1.GetTriedBucket(nKey1, ngm_asmap) != info2.GetTriedBucket(nKey1, ngm_asmap));
@@ -654,7 +671,10 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
     for (int j = 0; j < 255; j++) {
         AddrInfo infoj = AddrInfo(
             CAddress(ResolveService("101." + ToString(j) + ".1.1"), NODE_NONE),
-            ResolveIP("101." + ToString(j) + ".1.1"));
+            TEST_ASN,
+            ResolveIP("101." + ToString(j) + ".1.1"),
+            TEST_SOURCE_ASN
+        );
         int bucket = infoj.GetTriedBucket(nKey1, ngm_asmap);
         buckets.insert(bucket);
     }
@@ -666,7 +686,10 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
     for (int j = 0; j < 255; j++) {
         AddrInfo infoj = AddrInfo(
             CAddress(ResolveService("250." + ToString(j) + ".1.1"), NODE_NONE),
-            ResolveIP("250." + ToString(j) + ".1.1"));
+            TEST_ASN,
+            ResolveIP("250." + ToString(j) + ".1.1"),
+            TEST_SOURCE_ASN
+        );
         int bucket = infoj.GetTriedBucket(nKey1, ngm_asmap);
         buckets.insert(bucket);
     }
@@ -684,7 +707,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
 
     CNetAddr source1 = ResolveIP("250.1.2.1");
 
-    AddrInfo info1 = AddrInfo(addr1, source1);
+    AddrInfo info1 = AddrInfo(addr1, TEST_ASN, source1, TEST_SOURCE_ASN);
 
     uint256 nKey1 = (HashWriter{} << 1).GetHash();
     uint256 nKey2 = (HashWriter{} << 2).GetHash();
@@ -698,7 +721,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     BOOST_CHECK(info1.GetNewBucket(nKey1, ngm_asmap) != info1.GetNewBucket(nKey2, ngm_asmap));
 
     // Test: Ports should not affect bucket placement in the addr
-    AddrInfo info2 = AddrInfo(addr2, source1);
+    AddrInfo info2 = AddrInfo(addr2, TEST_ASN, source1, TEST_SOURCE_ASN);
     BOOST_CHECK(info1.GetKey() != info2.GetKey());
     BOOST_CHECK_EQUAL(info1.GetNewBucket(nKey1, ngm_asmap), info2.GetNewBucket(nKey1, ngm_asmap));
 
@@ -706,7 +729,10 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     for (int i = 0; i < 255; i++) {
         AddrInfo infoi = AddrInfo(
             CAddress(ResolveService("250.1.1." + ToString(i)), NODE_NONE),
-            ResolveIP("250.1.1." + ToString(i)));
+            TEST_ASN,
+            ResolveIP("250.1.1." + ToString(i)),
+            TEST_SOURCE_ASN
+        );
         int bucket = infoi.GetNewBucket(nKey1, ngm_asmap);
         buckets.insert(bucket);
     }
@@ -719,7 +745,10 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
         AddrInfo infoj = AddrInfo(CAddress(
                                         ResolveService(
                                             ToString(250 + (j / 255)) + "." + ToString(j % 256) + ".1.1"), NODE_NONE),
-            ResolveIP("251.4.1.1"));
+            TEST_ASN,
+            ResolveIP("251.4.1.1"),
+            TEST_SOURCE_ASN
+        );
         int bucket = infoj.GetNewBucket(nKey1, ngm_asmap);
         buckets.insert(bucket);
     }
@@ -731,7 +760,10 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     for (int p = 0; p < 255; p++) {
         AddrInfo infoj = AddrInfo(
             CAddress(ResolveService("250.1.1.1"), NODE_NONE),
-            ResolveIP("101." + ToString(p) + ".1.1"));
+            TEST_ASN,
+            ResolveIP("101." + ToString(p) + ".1.1"),
+            TEST_SOURCE_ASN
+        );
         int bucket = infoj.GetNewBucket(nKey1, ngm_asmap);
         buckets.insert(bucket);
     }
@@ -743,7 +775,10 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     for (int p = 0; p < 255; p++) {
         AddrInfo infoj = AddrInfo(
             CAddress(ResolveService("250.1.1.1"), NODE_NONE),
-            ResolveIP("250." + ToString(p) + ".1.1"));
+            TEST_ASN,
+            ResolveIP("250." + ToString(p) + ".1.1"),
+            TEST_SOURCE_ASN
+        );
         int bucket = infoj.GetNewBucket(nKey1, ngm_asmap);
         buckets.insert(bucket);
     }
@@ -763,10 +798,12 @@ BOOST_AUTO_TEST_CASE(addrman_serialization)
 
     DataStream stream{};
 
-    CAddress addr = CAddress(ResolveService("250.1.1.1"), NODE_NONE);
-    CNetAddr default_source;
+    CAddress addr = CAddress(ResolveService("250.1.1.1"), NODE_NONE); // ASN 1000 in test asmap
+    const int32_t EXPECTED_ASN = 1000;
+    CNetAddr source = ResolveIP("101.3.0.0"); // ASN 3 in test asmap
+    const int32_t EXPECTED_SOURCE_ASN = 3;
 
-    addrman_asmap1->Add({addr}, default_source);
+    addrman_asmap1->Add({addr}, source);
 
     stream << *addrman_asmap1;
     // serizalizing/deserializing addrman with the same asmap
@@ -779,6 +816,20 @@ BOOST_AUTO_TEST_CASE(addrman_serialization)
 
     BOOST_CHECK(addr_pos1 == addr_pos2);
 
+    const auto entries1 = addrman_asmap1->GetEntries(false);
+    BOOST_CHECK(entries1.size() == 1);
+    const AddrInfo info1 = entries1.front().first;
+    BOOST_CHECK(info1.mapped_as == EXPECTED_ASN);
+    BOOST_CHECK(info1.source_mapped_as == EXPECTED_SOURCE_ASN);
+
+    const auto entries1_dup = addrman_asmap1_dup->GetEntries(false);
+    BOOST_CHECK(entries1_dup.size() == 1);
+    const AddrInfo info1_dup = entries1_dup.front().first;
+    BOOST_CHECK(info1_dup.mapped_as == EXPECTED_ASN);
+    BOOST_CHECK(info1_dup.source_mapped_as == EXPECTED_SOURCE_ASN);
+
+    BOOST_CHECK(info1 == info1_dup);
+
     // deserializing asmaped peers.dat to non-asmaped addrman
     stream << *addrman_asmap1;
     stream >> *addrman_noasmap;
@@ -790,7 +841,7 @@ BOOST_AUTO_TEST_CASE(addrman_serialization)
     // deserializing non-asmaped peers.dat to asmaped addrman
     addrman_asmap1 = std::make_unique<AddrMan>(netgroupman, DETERMINISTIC, ratio);
     addrman_noasmap = std::make_unique<AddrMan>(EMPTY_NETGROUPMAN, DETERMINISTIC, ratio);
-    addrman_noasmap->Add({addr}, default_source);
+    addrman_noasmap->Add({addr}, source);
     stream << *addrman_noasmap;
     stream >> *addrman_asmap1;
 
@@ -804,7 +855,7 @@ BOOST_AUTO_TEST_CASE(addrman_serialization)
     addrman_noasmap = std::make_unique<AddrMan>(EMPTY_NETGROUPMAN, DETERMINISTIC, ratio);
     CAddress addr1 = CAddress(ResolveService("250.1.1.1"), NODE_NONE);
     CAddress addr2 = CAddress(ResolveService("250.2.1.1"), NODE_NONE);
-    addrman_noasmap->Add({addr, addr2}, default_source);
+    addrman_noasmap->Add({addr, addr2}, source);
     AddressPosition addr_pos5 = addrman_noasmap->FindAddressEntry(addr1).value();
     AddressPosition addr_pos6 = addrman_noasmap->FindAddressEntry(addr2).value();
     BOOST_CHECK(addr_pos5.bucket != addr_pos6.bucket);
@@ -1082,7 +1133,7 @@ static auto MakeCorruptPeersDat()
     CAddress addr = CAddress(serv.value(), NODE_NONE);
     std::optional<CNetAddr> resolved{LookupHost("252.2.2.2", false)};
     BOOST_REQUIRE(resolved.has_value());
-    AddrInfo info = AddrInfo(addr, resolved.value());
+    AddrInfo info = AddrInfo(addr, TEST_ASN, resolved.value(), TEST_SOURCE_ASN);
     s << CAddress::V1_DISK(info);
 
     return s;

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -9,6 +9,7 @@ Tests correspond to code in rpc/net.cpp.
 
 from decimal import Decimal
 from itertools import product
+import os
 import platform
 import time
 
@@ -27,6 +28,7 @@ from test_framework.util import (
 )
 from test_framework.wallet import MiniWallet
 
+TEST_ASN = 3
 
 def assert_net_servicesnames(servicesflag, servicenames):
     """Utility that checks if all flags are correctly decoded in
@@ -57,7 +59,8 @@ def seed_addrman(node):
     assert_equal(node.addpeeraddress(address="pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion", tried=True, port=8333), success)
     assert_equal(node.addpeeraddress(address="nrfj6inpyf73gpkyool35hcmne5zwfmse3jl3aw23vk7chdemalyaqad.onion", port=45324, tried=True), success)
     assert_equal(node.addpeeraddress(address="c4gfnttsuwqomiygupdqqqyy5y5emnk5c73hrfvatri67prd7vyq.b32.i2p", port=8333), success)
-
+    # Add one address that is mapped in the test asmap file.
+    assert_equal(node.addpeeraddress(address=f"101.{TEST_ASN}.0.0", tried=True, port=8333), success)
 
 class NetTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -452,8 +455,8 @@ class NetTest(BitcoinTestFramework):
         seed_addrman(node)
 
         expected_network_count = {
-            'all_networks': {'new': 4, 'tried': 4, 'total': 8},
-            'ipv4': {'new': 1, 'tried': 1, 'total': 2},
+            'all_networks': {'new': 4, 'tried': 5, 'total': 9},
+            'ipv4': {'new': 1, 'tried': 2, 'total': 3},
             'ipv6': {'new': 1, 'tried': 1, 'total': 2},
             'onion': {'new': 0, 'tried': 2, 'total': 2},
             'i2p': {'new': 1, 'tried': 0, 'total': 1},
@@ -469,7 +472,8 @@ class NetTest(BitcoinTestFramework):
 
     def test_getrawaddrman(self):
         self.log.info("Test getrawaddrman")
-        self.restart_node(1, extra_args=["-cjdnsreachable", "-test=addrman"], clear_addrman=True)
+        asmap_file = os.path.join(self.config["environment"]["SRCDIR"], 'src/test/data/asmap.raw')
+        self.restart_node(1, extra_args=["-cjdnsreachable", "-test=addrman", f"-asmap={asmap_file}"], clear_addrman=True)
         node = self.nodes[1]
         self.addr_time = int(time.time())
         node.setmocktime(self.addr_time)
@@ -489,6 +493,12 @@ class NetTest(BitcoinTestFramework):
             assert_equal(result["source"], expected["source"])
             assert_equal(result["source_network"], expected["source_network"])
             assert_equal(result["time"], self.addr_time)
+            if "mapped_as" in expected:
+                assert_equal(result["mapped_as"], expected["mapped_as"])
+                assert_equal(result["source_mapped_as"], expected["source_mapped_as"])
+            else:
+                assert("mapped_as" not in result)
+                assert("source_mapped_as" not in result)
 
         def check_getrawaddrman_entries(expected):
             """Utility to compare a getrawaddrman result with expected addrman contents"""
@@ -504,7 +514,7 @@ class NetTest(BitcoinTestFramework):
                     assert bucket_position == expected_entry["bucket_position"]
                     check_addr_information(entry, expected_entry)
 
-        # we expect 4 new and 4 tried table entries in the addrman which were added using seed_addrman()
+        # we expect 4 new and 5 tried table entries in the addrman which were added using seed_addrman()
         expected = {
             "new": [
                     {
@@ -580,6 +590,17 @@ class NetTest(BitcoinTestFramework):
                         "source": "nrfj6inpyf73gpkyool35hcmne5zwfmse3jl3aw23vk7chdemalyaqad.onion",
                         "source_network": "onion",
                         "port": 45324,
+                    },
+                    {
+                        "bucket_position": "65/21",
+                        "address": "101.3.0.0",
+                        "services": 9,
+                        "network": "ipv4",
+                        "source": "101.3.0.0",
+                        "source_network": "ipv4",
+                        "port": 8333,
+                        "mapped_as": TEST_ASN,
+                        "source_mapped_as": TEST_ASN,
                     }
             ]
         }


### PR DESCRIPTION
When using the hidden `getrawaddrman` RPC on a node with `-asmap` enabled, ...